### PR TITLE
Optimize build process by adding linker flags for smaller binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ watch:
 	@wgo run ./cmd/main.go all
 
 build:
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/quran-macos ./cmd/main.go
-	GOOS=linux GOARCH=amd64 go build -o  ./bin/quran-linux ./cmd/main.go
-	GOOS=windows GOARCH=amd64 go build -o  ./bin/quran-windows.exe ./cmd/main.go
+	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o ./bin/quran-macos ./cmd/main.go
+	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o  ./bin/quran-linux ./cmd/main.go
+	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o  ./bin/quran-windows.exe ./cmd/main.go
 
 run:
 	./bin/quran-linux all


### PR DESCRIPTION
This pull request optimizes the build process by adding linker flags for smaller binary size. The `go build` command now includes the `-ldflags="-s -w"` option, which strips the symbol table and debug information from the binary. This results in smaller binary sizes for the macOS, Linux, and Windows builds.